### PR TITLE
[SBL-143] 에러 코드 확인 로직 추가

### DIFF
--- a/app/core/util/document_manager.py
+++ b/app/core/util/document_manager.py
@@ -29,6 +29,8 @@ class DocumentManager:
     
     def text_from_txt_file_url(self, file_url: str):
         response = requests.get(file_url)
+        if(response.status_code != 200):
+            raise business_exception(ErrorCode.FILE_NOT_FOUND)
         response.encoding = 'utf-8'
         text_content = response.text
     

--- a/app/core/util/document_manager.py
+++ b/app/core/util/document_manager.py
@@ -1,4 +1,6 @@
+from email.policy import HTTP
 import requests
+from http import HTTPStatus
 from langchain.docstore.document import Document
 from langchain_community.document_loaders import PyMuPDFLoader
 from app.error.error_code import ErrorCode
@@ -29,7 +31,7 @@ class DocumentManager:
     
     def text_from_txt_file_url(self, file_url: str):
         response = requests.get(file_url)
-        if(response.status_code != 200):
+        if(response.status_code != HTTPStatus.OK):
             raise business_exception(ErrorCode.FILE_NOT_FOUND)
         response.encoding = 'utf-8'
         text_content = response.text

--- a/app/error/error_code.py
+++ b/app/error/error_code.py
@@ -12,3 +12,5 @@ class ErrorCode(Enum):
     
     TEXT_TOO_LONG = (HTTPStatus.BAD_REQUEST, {"code":"PY0002", "message":"텍스트 길이는 1만 2천자 이하여야 합니다"})
     FILE_EXTENSION_NOT_SUPPORTED = (HTTPStatus.BAD_REQUEST, {"code":"PY0003", "message":"지원하지 않는 파일 확장자입니다"})
+    FILE_NOT_FOUND = (HTTPStatus.NOT_FOUND, {"code":"PY0004", "message":"파일을 찾을 수 없습니다"})
+


### PR DESCRIPTION
## 📢 설명
response 코드가 200인지 확인 
이를 통해 S3에서 존재하지 않는 객체를 가져올 때 반환되는 코드인 403forbidden 코드를 받으면 텍스트 분석을 수행하지 않고 예외를 던집니다

추후 request.get으로 가져와야되는 상황이 더 발생한다면 
```
response = requests.get(file_url)
if(response.status_code != 200):
    raise business_exception(ErrorCode.FILE_NOT_FOUND)
```
코드 분리 예정

+) 20240926 : 상태코드 ENUM으로 변경
```
 if(response.status_code != HTTPStatus.OK):
     raise business_exception(ErrorCode.FILE_NOT_FOUND)
```

## ✅ 체크 리스트
- [x] 없는 .txt파일을 보냈을 때 오류가 발생하는지 확인
```
{
  "job": "string",
  "group_name": "string",
  "file_url": "https://files.sulmoon.io/123.txt"
}
```
예상 오류
```
{
  "detail": {
    "code": "PY0004",
    "message": "파일을 찾을 수 없습니다"
  }
}
```
- [x] 존재하는 .txt파일을 보냈을 때는 오류가 발생하지 않는지 확인
```
{
  "job": "string",
  "group_name": "string",
  "file_url": "https://files.sulmoon.io/%EC%98%A8%EC%84%B8%EC%83%81%EC%9D%B4%EB%A6%AC%EC%84%A0%EC%A1%B1-%EC%8B%A0%EC%B0%BD%EC%84%AD.txt"
}
```