### PR TITLE
[SBL-197] chat_session_id는 survey_id를 참조하도록 함

### DIFF
--- a/app/core/prompt/edit/edit_question_prompt.py
+++ b/app/core/prompt/edit/edit_question_prompt.py
@@ -2,15 +2,34 @@ from langchain.prompts import PromptTemplate
 
 edit_question_prompt = PromptTemplate(
     template="""
-    ### Instructions
-    1. Edit user survey data following prompt: {user_prompt}
-    2. Reference existing survey data
-    3. questionType should be SINGLE_CHOICE(allow only one choice) / MULTIPLE_CHOICE(allow multiple choices) / TEXT_RESPONSE(text response)
-    4. id: keep it or null
-
-    ### User Question
+    You are a survey editor that edit user question, which is part of the section, based on user prompts:{user_prompt}
+    Follow the instructions below to edit a question
+    
+    ### User question
     {user_question}
-
+    
+    ### Instructions
+    1. Reference the document summation below to edit the question
+    2. Ensure adherence to the Creation Requirements provided when you edit the question.
+    
+     ### Creation Requirements
+    - **Rules**
+    1. {user_prompt} (e.g., Include questions on a specific topic.)
+    2. Suggest choices if the question is multiple choice.
+    3. Suggest whether the question is required or not.
+    4. Keep id or set id null
+    - **Content**
+    1. Questions
+        
+    ### output
+    #### Questions
+    ##### Question Id
+    ##### Belonging Section: The section to which the question belongs
+    ##### Question Type: SINGLE_CHOICE(allow only one choice) / MULTIPLE_CHOICE(allow multiple choices) / TEXT_RESPONSE(text response)
+    ##### Title : Question's title
+    ##### Choices: Question's choice
+    ##### isAllowOtherChoice: True / False
+    ##### isRequired: True / False
     """,
     input_variables=["user_prompt", "user_question"],
 )

--- a/app/core/prompt/edit/edit_section_prompt.py
+++ b/app/core/prompt/edit/edit_section_prompt.py
@@ -2,15 +2,39 @@ from langchain.prompts import PromptTemplate
 
 edit_section_prompt = PromptTemplate(
     template="""
-    ### Instructions
-    1. Edit user survey data following prompt: {user_prompt}
-    2. Reference existing survey data
-    3. questionType should be SINGLE_CHOICE(allow only one choice) / MULTIPLE_CHOICE(allow multiple choices) / TEXT_RESPONSE(text response)
-    4. id: keep it or null
+    You are a survey editor that edits the user section, which is part of the survey, based on user prompts: {user_prompt}
+    Follow the instructions below to edit a section
 
-    ### User Section
+    ### User Survey
     {user_section}
+
+    ### Instructions
+    1. Reference the document summation below to edit the section
+    2. Ensure adherence to the Creation Requirements provided when you edit the section
     
+     ### Creation Requirements
+    - **Rules**
+    1. {user_prompt} (e.g., Include questions on a specific topic.)
+    2. Suggest choices if the question is multiple choice.
+    3. Suggest whether the question is required or not.
+    4. Keep Section Id, Question Id or set them null if you want to create a new one.
+    - **Content**
+    1. Sections
+    2. Questions
+        
+    ### output
+    ##### Section Id
+    ##### Section Title
+    ##### Section Description
+
+    #### Questions
+    ##### Question Id
+    ##### Belonging Section: The section to which the question belongs
+    ##### Question Type: SINGLE_CHOICE(allow only one choice) / MULTIPLE_CHOICE(allow multiple choices) / TEXT_RESPONSE(text response)
+    ##### Title : Question's title
+    ##### Choices: Question's choice
+    ##### isAllowOtherChoice: True / False
+    ##### isRequired: True / False
     """,
     input_variables=["user_prompt", "user_section"],
 )

--- a/app/core/prompt/edit/edit_survey_prompt.py
+++ b/app/core/prompt/edit/edit_survey_prompt.py
@@ -2,15 +2,48 @@ from langchain.prompts import PromptTemplate
 
 edit_survey_prompt = PromptTemplate(
     template="""
-    ### Instructions
-    1. Edit user survey data following prompt: {user_prompt}
-    2. Reference existing survey data
-    3. questionType should be SINGLE_CHOICE(allow only one choice) / MULTIPLE_CHOICE(allow multiple choices) / TEXT_RESPONSE(text response)
-    4. id: keep it or null
+    You are a survey editor that edit user survey based on user prompts:{user_prompt}
+    Follow the instructions below to edit a survey
 
     ### User Survey
     {user_survey}
+    
+    ### Instructions
+    1. Reference the document summation below to edit the survey.
+    2. Ensure adherence to the Creation Requirements provided when you edit the survey.
+    
+     ### Creation Requirements
+    - **Rules**
+    1. {user_prompt} (e.g., Include questions on a specific topic.)
+    2. Suggest choices if the question is multiple choice.
+    3. Suggest whether the question is required or not.
+    4. Keep Survey Id, Section Id, Question Id or set them null if you want to create a new one.
+    - **Content**
+    1. Survey Title: Create a survey title based on the reference materials ended with "~에 대한 조사" (e.g., 설문 제작 및 참여에 대한 경험 조사)
+    2. Survey Description: Write a survey description based on the reference materials.
+    3. Finish Message: Write a completion message based on the reference materials.
+    4. Sections
+    5. Questions
 
+    ### output
+    #### Survey Id
+    #### Survey Title
+    #### Survey Description
+    ##### Finish Message
+
+    #### Sections
+    ##### Section Id
+    ##### Section Title
+    ##### Section Description
+
+    #### Questions
+    ##### Question Id
+    ##### Belonging Section: The section to which the question belongs
+    ##### Question Type: SINGLE_CHOICE(allow only one choice) / MULTIPLE_CHOICE(allow multiple choices) / TEXT_RESPONSE(text response)
+    ##### Title : Question's title
+    ##### Choices: Question's choice
+    ##### isAllowOtherChoice: True / False
+    ##### isRequired: True / False
     """,
     input_variables=["user_prompt", "user_survey"],
 )

--- a/app/core/prompt/generate/survey_creation_prompt.py
+++ b/app/core/prompt/generate/survey_creation_prompt.py
@@ -31,21 +31,20 @@ survey_creation_prompt = PromptTemplate(
         
     ### output
     #### Survey Title
-
     #### Survey Description
-
     ##### Finish Message
 
     #### Sections
+    ##### Section Title
+    ##### Section Description
 
     #### Questions
-    - **Format**
-    section: The section to which the question belongs
-    questionType: SINGLE_CHOICE(allow only one choice) / MULTIPLE_CHOICE(allow multiple choices) / TEXT_RESPONSE(text response)
-    question: Suggested question's title
-    choices: Suggested question's choice
-    isAllowOtherChoice: True / False
-    isRequired: True / False
+    ##### Belonging Section: The section to which the question belongs
+    ##### Question Type: SINGLE_CHOICE(allow only one choice) / MULTIPLE_CHOICE(allow multiple choices) / TEXT_RESPONSE(text response)
+    ##### Title : Question's title
+    ##### Choices: Question's choice
+    ##### isAllowOtherChoice: True / False
+    ##### isRequired: True / False
     """,
     input_variables=["user_prompt", "document", "guide"],
 )

--- a/app/core/util/ai_manager.py
+++ b/app/core/util/ai_manager.py
@@ -1,14 +1,11 @@
-import uuid
-
-from pydantic.v1 import UUID4
-
+from uuid import UUID
 from app.core.config.ai_model import chat_model
 from langchain.schema import HumanMessage
 from app.core.config.message_storage import get_message_storage
 
 
 class AIManager:
-    def __init__(self, chat_session_id: UUID4):
+    def __init__(self, chat_session_id: UUID):
         self._chat_session_id = str(chat_session_id)
 
     @property

--- a/app/core/util/ai_manager.py
+++ b/app/core/util/ai_manager.py
@@ -1,16 +1,19 @@
 import uuid
+
+from pydantic.v1 import UUID4
+
 from app.core.config.ai_model import chat_model
 from langchain.schema import HumanMessage
 from app.core.config.message_storage import get_message_storage
 
 
 class AIManager:
-    def __init__(self):
-        self._session_id = str(uuid.uuid4())
+    def __init__(self, chat_session_id: UUID4):
+        self._chat_session_id = str(chat_session_id)
 
     @property
     def session_id(self):
-        return self._session_id
+        return self._chat_session_id
 
     def chat(self, prompt):
         response = chat_model.invoke(
@@ -29,8 +32,8 @@ class AIManager:
         )
         return response.content
 
-    def chat_with_history(self, prompt, session_id, is_new_chat_save):
-        message_storage = get_message_storage(str(session_id))
+    def chat_with_history(self, prompt, is_new_chat_save):
+        message_storage = get_message_storage(self._chat_session_id)
 
         message_history = message_storage.messages
 
@@ -49,8 +52,8 @@ class AIManager:
         )
         return response.content
 
-    async def async_chat_with_history(self, prompt, session_id, is_new_chat_save):
-        message_storage = get_message_storage(session_id)
+    async def async_chat_with_history(self, prompt, is_new_chat_save):
+        message_storage = get_message_storage(self._chat_session_id)
 
         message_history = message_storage.messages
 

--- a/app/dto/model/question.py
+++ b/app/dto/model/question.py
@@ -1,12 +1,13 @@
 from typing import Optional
 from typing import List
-from pydantic import BaseModel, Field, UUID4
+from uuid import UUID
+from pydantic import BaseModel, Field
 
 from app.dto.model.question_type import QuestionType
 
 
 class Question(BaseModel):
-    id: Optional[UUID4] = Field(default=None, description="Unique identifier or null")
+    id: Optional[UUID] = Field(default=None, description="Unique identifier or null")
     question_type: QuestionType = Field(
         description="Type of the question: SINGLE_CHOICE, MULTIPLE_CHOICE, TEXT_RESPONSE"
     )

--- a/app/dto/model/section.py
+++ b/app/dto/model/section.py
@@ -1,10 +1,11 @@
 from typing import Optional
 from app.dto.model.question import Question
-from pydantic import BaseModel, Field, UUID4
+from pydantic import BaseModel, Field
+from uuid import UUID
 
 
 class Section(BaseModel):
-    id: Optional[UUID4] = Field(default=None, description="Unique identifier or null")
+    id: Optional[UUID] = Field(default=None, description="Unique identifier or null")
     title: str = Field(description="Title of the section")
     description: str = Field(description="Description of the section")
     questions: list[Question] = Field(description="Questions included in the section")

--- a/app/dto/model/survey.py
+++ b/app/dto/model/survey.py
@@ -1,11 +1,12 @@
 from typing import Optional
 
 from app.dto.model.section import Section
-from pydantic import BaseModel, Field, UUID4
+from pydantic import BaseModel, Field
+from uuid import UUID
 
 
 class Survey(BaseModel):
-    id: Optional[UUID4] = Field(default=None, description="Unique identifier or null")
+    id: Optional[UUID] = Field(default=None, description="Unique identifier or null")
     title: str = Field(description="Title of the survey")
     description: str = Field(description="Greeting message at the start of the survey")
     finish_message: str = Field(

--- a/app/dto/request/survey_generate_with_file_url_request.py
+++ b/app/dto/request/survey_generate_with_file_url_request.py
@@ -1,3 +1,4 @@
+from uuid import UUID
 from app.error.business_exception import business_exception
 from app.error.error_code import ErrorCode
 from pydantic import BaseModel, field_validator
@@ -8,6 +9,7 @@ USER_PROMPT_TEXT_LIMIT = 1000
 
 
 class SurveyGenerateWithFileUrlRequest(BaseModel):
+    chat_session_id: UUID
     job: str
     group_name: str
     file_url: str

--- a/app/dto/request/survey_generate_with_text_document_request.py
+++ b/app/dto/request/survey_generate_with_text_document_request.py
@@ -1,3 +1,4 @@
+from uuid import UUID
 from app.error.business_exception import business_exception
 from app.error.error_code import ErrorCode
 from pydantic import BaseModel, field_validator
@@ -7,6 +8,7 @@ USER_PROMPT_TEXT_LIMIT = 1000
 
 
 class SurveyGenerateWithTextDocumentRequest(BaseModel):
+    chat_session_id: UUID
     job: str
     group_name: str
     text_document: str

--- a/app/dto/response/survey_generate_response.py
+++ b/app/dto/response/survey_generate_response.py
@@ -1,8 +1,7 @@
-from uuid import UUID
 from pydantic import BaseModel
+
 from app.dto.model.survey import Survey
 
 
 class SurveyGenerateResponse(BaseModel):
-    chat_session_id: UUID
     survey: Survey

--- a/app/service/survey_generate_service.py
+++ b/app/service/survey_generate_service.py
@@ -1,5 +1,5 @@
 import asyncio
-
+from pydantic import UUID4
 from langchain.output_parsers import PydanticOutputParser
 
 from app.core.prompt.summation.document_summation_prompt import (
@@ -28,7 +28,7 @@ from app.dto.model.survey import Survey
 
 class SurveyGenerateService:
     def __init__(self):
-        self.ai_manager = AIManager()
+        self.ai_manager = None
         self.document_manger = DocumentManager()
         self.survey_creation_prompt = survey_creation_prompt
         self.survey_parsing_prompt = survey_parsing_prompt
@@ -37,6 +37,7 @@ class SurveyGenerateService:
     async def generate_survey_with_file_url(
         self, request: SurveyGenerateWithFileUrlRequest
     ):
+        self.ai_manager = AIManager(request.chat_session_id)
         text_document = self.__get_text_document_from_file_url(request.file_url)
 
         survey_generate_content = self._SurveyGenerateContent(
@@ -53,6 +54,7 @@ class SurveyGenerateService:
     async def generate_survey_with_text_document(
         self, request: SurveyGenerateWithTextDocumentRequest
     ):
+        self.ai_manager = AIManager(request.chat_session_id)
         survey_generate_content = self._SurveyGenerateContent(
             job=request.job,
             group=request.group_name,
@@ -66,7 +68,13 @@ class SurveyGenerateService:
 
     # private
     class _SurveyGenerateContent:
-        def __init__(self, job: str, group: str, text_document: str, user_prompt: str):
+        def __init__(
+            self,
+            job: str,
+            group: str,
+            text_document: str,
+            user_prompt: str,
+        ):
             self.job = job
             self.group = group
             self.text_document = text_document
@@ -82,7 +90,7 @@ class SurveyGenerateService:
 
         user_prompt_with_basic_prompt = user_prompt
         if job != "":
-            user_prompt_with_basic_prompt += f" {job}을 위한 설문조사를 생성해주세요."
+            user_prompt_with_basic_prompt += f" {job}을 대상으로 하는 설문조사를 생성해주세요."
 
         if group != "":
             user_prompt_with_basic_prompt += f" 인사말에는 {group} 소속임을 밝히는 말을 포함해주세요."
@@ -102,17 +110,13 @@ class SurveyGenerateService:
             document_summation_task, survey_generation_task
         )
 
-        return SurveyGenerateResponse(
-            chat_session_id=self.ai_manager.session_id,
-            survey=parsed_generated_survey,
-        )
+        return SurveyGenerateResponse(survey=parsed_generated_survey)
 
     async def __summarize_document(self, text_document):
         document_summation = await FunctionExecutionTimeMeasurer.run_async_function(
             "문서 요약 태스크",
             self.ai_manager.async_chat_with_history,
             document_summation_prompt.format(user_document=text_document),
-            self.ai_manager.session_id,
             is_new_chat_save=True,
         )
         return document_summation

--- a/app/service/survey_generate_service.py
+++ b/app/service/survey_generate_service.py
@@ -1,7 +1,5 @@
 import asyncio
-from pydantic import UUID4
 from langchain.output_parsers import PydanticOutputParser
-
 from app.core.prompt.summation.document_summation_prompt import (
     document_summation_prompt,
 )


### PR DESCRIPTION
## 📢 설명 - https://github.com/SUIN-BUNDANG-LINE/Backend/pull/91 와 연계하여 테스트
- 빈 설문일때는 edit요청이 설문조사를 잘 못만들어내어 프롬프트를 조정함
- ai_manager 생성시에 chat_session_id를 입력받게 함
- request dto에 chat_session_id도 받게 함

## ✅ 체크 리스트
- [x] https://github.com/SUIN-BUNDANG-LINE/Backend/pull/91 와 연계하여 테스트
- [x] 코드 리뷰